### PR TITLE
Fix banners being white on the search-page and settings-page

### DIFF
--- a/Chrome & FireFox/injection-scripts/search-page.js
+++ b/Chrome & FireFox/injection-scripts/search-page.js
@@ -197,6 +197,18 @@ body {
 .notifications-banner-close {
 	color: var(--text) !important;
 }
+.banner {
+	background: var(--form) !important;
+}
+.banner__content {
+	color: var(--text) !important;
+}
+.banner__close:hover::after {
+	background: var(--form);
+}
+.banner__close {
+	background: var(--lighter-background) !important;
+}
 
 /* Dropdown menu */
 .dropdown-menu {

--- a/Chrome & FireFox/injection-scripts/settings-page.js
+++ b/Chrome & FireFox/injection-scripts/settings-page.js
@@ -139,6 +139,18 @@ input, .list > li, .list > li:focus, .list > li:active {
 .notifications-dropdown a:hover {
     background: var(--lighter-background) !important;
 }
+.banner {
+	background: var(--form) !important;
+}
+.banner__content {
+	color: var(--text) !important;
+}
+.banner__close:hover::after {
+	background: var(--form);
+}
+.banner__close {
+	background: var(--lighter-background) !important;
+}
 
 /* Burger menu */
 .main-nav button {


### PR DESCRIPTION
Adding the seemingly new classnames for the banner on the search-page and settings-page. Seems to have been changed on the news-and-videos-page, so I just took the changes from there, and put them here. Kept the old changes for the banners as it seems that it may still be using the old classnames on the current full-release as I've understood it. 

I don't know what's up with the bottom change on the settings-page as I didn't even touch that part:
![bilde](https://user-images.githubusercontent.com/68151654/144752994-599a4ce7-4f6f-468d-aafa-7fd133d014de.png)
